### PR TITLE
af async/await

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,24 +9,27 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "chzzkSwift",
-            targets: ["chzzkSwift"]),
+            targets: ["chzzkSwift"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.9.1"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.6")
-    ]
-    ,
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.6"),
+    ],
+
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "chzzkSwift",
             dependencies: [
-             .product(name: "Alamofire", package: "Alamofire"),   
-            .product(name: "Starscream", package: "Starscream")
-            ]),
+                .product(name: "Alamofire", package: "Alamofire"),
+                .product(name: "Starscream", package: "Starscream"),
+            ]
+        ),
         .testTarget(
             name: "chzzkSwiftTests",
-            dependencies: ["chzzkSwift", "Alamofire", "Starscream"]),
+            dependencies: ["chzzkSwift", "Alamofire", "Starscream"]
+        ),
     ]
 )

--- a/Sources/ChzzkSwift/ChzzkSwift.swift
+++ b/Sources/ChzzkSwift/ChzzkSwift.swift
@@ -1,22 +1,45 @@
 import Alamofire
 import Starscream
 
+@available(macOS 10.15, *)
 public class ChzzkSwift {
     private let apiClient: APIClient
-    
+
     public init(apiClient: APIClient = APIClient.shared) {
         self.apiClient = apiClient
         print("chzzkSwift initialized")
     }
 
-    public func getRecommendationChannels() {
+    public func getRecommendationChannels() async throws -> [RecommendationChannel] {
         let endpoint = ChzzkAPI.getRecommendationChannels
-        apiClient.request(endpoint: endpoint) { (result: Result<RecommendationResponse, AFError>) in
-            switch result {
-            case .success(let data):
-                print("Recommendation Channels: \(data)")
-            case .failure(let error):
-                print("Error: \(error)")
+        return try await withCheckedThrowingContinuation { continuation in
+            apiClient.request(endpoint: endpoint) { (result: Result<RecommendationResponse, AFError>) in
+                switch result {
+                case let .success(data):
+                    if data.code != 200 {
+                        continuation.resume(throwing: ChzzkError.error(code: data.code, message: data.message!))
+                    }
+                    continuation.resume(returning: data.content.recommendationChannels)
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    public func searchChannels(_ channelName: String, offset: Int = 0, size: Int = 13) async throws -> [SearchData] {
+        let endpoint = ChzzkAPI.searchChannels(keyword: channelName, offset: 0, size: 13, withFirstChannelContent: true)
+        return try await withCheckedThrowingContinuation { continuation in
+            apiClient.request(endpoint: endpoint) { (result: Result<SearchResponse, AFError>) in
+                switch result {
+                case let .success(data):
+                    if data.code != 200 {
+                        continuation.resume(throwing: ChzzkError.error(code: data.code, message: data.message!))
+                    }
+                    continuation.resume(returning: data.content.data)
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
             }
         }
     }

--- a/Sources/ChzzkSwift/Model/RecommendationChannel.swift
+++ b/Sources/ChzzkSwift/Model/RecommendationChannel.swift
@@ -10,20 +10,22 @@ struct RecommendationContent: Decodable {
     let recommendationChannels: [RecommendationChannel]
 }
 
-struct RecommendationChannel: Decodable {
+struct Streamer: Decodable {
+    let openLive: Bool
+}
+
+// MARK: - public section
+
+public struct LiveInfo: Decodable {
+    let liveTitle: String
+    let concurrentUserCount: Int
+    let liveCategoryValue: String
+}
+
+public struct RecommendationChannel: Decodable {
     let channelId: String
     let channel: Channel
     let streamer: Streamer
     let liveInfo: LiveInfo
     let contentLineage: String
-}
-
-struct Streamer: Decodable {
-    let openLive: Bool
-}
-
-struct LiveInfo: Decodable {
-    let liveTitle: String
-    let concurrentUserCount: Int
-    let liveCategoryValue: String
 }

--- a/Sources/ChzzkSwift/Model/SearchChannel.swift
+++ b/Sources/ChzzkSwift/Model/SearchChannel.swift
@@ -12,20 +12,27 @@ struct SearchContent: Decodable {
     let data: [SearchData]
 }
 
+// MARK: - 좀 더 알아봐야하는 부분
+
 struct Page: Decodable {
     let next: Next
 }
 
 struct Next: Decodable {
-    let offset: Int
+    // 기본적으로 offset은 한번에 13식 증가함. 즉, 한페이지에 채널 13개씩 보여줌
+    // 사이즈 부분을 건들면 한페이지에 보여지는 채널수를 조절할 수 있음
+    // 이에 따라 offset값도 바뀜
+    let offset: Int //다음 페이지를 나타낼때 쓰임
 }
 
-struct SearchData: Decodable {
+// MARK: - public section
+
+public struct SearchData: Decodable {
     let channel: Channel
     let content: Content?
 }
 
-struct Channel: Codable {
+public struct Channel: Codable {
     let channelId: String
     let channelName: String
     let channelImageUrl: String?
@@ -35,12 +42,12 @@ struct Channel: Codable {
     let openLive: Bool?
 }
 
-struct Content: Decodable {
+public struct Content: Decodable {
     let live: Live?
     let videos: [Video]?
 }
 
-struct Live: Decodable {
+public struct Live: Decodable {
     let liveTitle: String
     let liveImageUrl: String
     let defaultThumbnailImageUrl: String?
@@ -59,7 +66,7 @@ struct Live: Decodable {
     let blindType: String?
 }
 
-struct Video: Decodable {
+public struct Video: Decodable {
     let videoNo: Int
     let videoId: String?
     let videoTitle: String

--- a/Sources/ChzzkSwift/Network/APIClient.swift
+++ b/Sources/ChzzkSwift/Network/APIClient.swift
@@ -1,10 +1,11 @@
 import Alamofire
+import Foundation
 
 public class APIClient {
-    static public let shared = APIClient()
-    
+    public static let shared = APIClient()
+
     private init() {}
-    
+
     func request<T: Decodable>(endpoint: APIEndpoint, completion: @escaping (Result<T, AFError>) -> Void) {
         let url = endpoint.baseURL + endpoint.path
         AF.request(url, method: endpoint.method, parameters: endpoint.parameters, headers: endpoint.headers).responseDecodable(of: T.self) { response in

--- a/Sources/ChzzkSwift/Network/ChzzkAPI.swift
+++ b/Sources/ChzzkSwift/Network/ChzzkAPI.swift
@@ -21,7 +21,7 @@ enum ChzzkAPI: APIEndpoint {
     case getLiveStatus(channelId: String)
     case getVideoHLSAddress(channelId: String)
     case getHLSRequest(url: String)
-    
+
     var baseURL: String {
         switch self {
         case .getUserStatus:
@@ -30,7 +30,7 @@ enum ChzzkAPI: APIEndpoint {
             return "https://api.chzzk.naver.com"
         }
     }
-    
+
     var path: String {
         switch self {
         case .getRecommendationChannels:
@@ -47,37 +47,37 @@ enum ChzzkAPI: APIEndpoint {
             return "/service/v1/search/channels"
         case .getChatUserInfo:
             return "/v1.1/chat-user-info"
-        case .getLiveStatus(let channelId):
+        case let .getLiveStatus(channelId):
             return "/polling/v3/channels/\(channelId)/live-status"
-        case .getVideoHLSAddress(let channelId):
+        case let .getVideoHLSAddress(channelId):
             return "/service/v3/channels/\(channelId)/live-detail"
-        case .getHLSRequest(let url):
+        case let .getHLSRequest(url):
             return url
         }
     }
-    
+
     var method: HTTPMethod {
         return .get
     }
-    
+
     var headers: HTTPHeaders? {
         return [
             "User-Agent": "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36",
             "Content-Type": "application/json",
-            "Accept": "application/json"
+            "Accept": "application/json",
         ]
     }
-    
+
     var parameters: Parameters? {
         switch self {
-        case .getRecommendedLiveBroadcasts(let deviceType):
+        case let .getRecommendedLiveBroadcasts(deviceType):
             return ["deviceType": deviceType]
-        case .searchChannels(let keyword, let offset, let size, let withFirstChannelContent):
+        case let .searchChannels(keyword, offset, size, withFirstChannelContent):
             return [
-                "keyword": keyword,
-                "offset": offset,
-                "size": size,
-                "withFirstChannelContent": withFirstChannelContent
+                "keyword": keyword, //검색어
+                "offset": offset, //페이지
+                "size": size, //한번에 보여줄 채널 수
+                "withFirstChannelContent": withFirstChannelContent, //첫 채널이 영상 컨텐츠를 보여 줄지 여부
             ]
         default:
             return nil

--- a/Sources/ChzzkSwift/Network/ChzzkError.swift
+++ b/Sources/ChzzkSwift/Network/ChzzkError.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum ChzzkError: Error {
+    case error(code: Int, message: String) //이름 재정의 필요
+}

--- a/Tests/ChzzkSwiftTests/ChzzkSwiftTests.swift
+++ b/Tests/ChzzkSwiftTests/ChzzkSwiftTests.swift
@@ -1,28 +1,30 @@
-import XCTest
 @testable import chzzkSwift
+import XCTest
 
 final class ChzzkSwiftTests: XCTestCase {
     var chzzkSwift: ChzzkSwift!
-    
+
     override func setUp() {
         super.setUp()
         chzzkSwift = ChzzkSwift()
     }
-    
+
     override func tearDown() {
         chzzkSwift = nil
         super.tearDown()
     }
-    
-    func testSearch() {
-        let expectation = self.expectation(description: "Search API Call")
-        
-        chzzkSwift.getRecommendationChannels()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10, handler: nil)
+
+    func testRecommendationChannels() async throws {
+        let res = try await chzzkSwift.getRecommendationChannels()
+
+        XCTAssert(res.count > 0)
+    }
+
+    func testSearch() async throws {
+        let res = try await chzzkSwift.searchChannels("랄로")
+
+        XCTAssert(res.count > 0)
+        print("res count: \(res.count)")
+        XCTAssertEqual(res[0].channel.channelName, "랄로")
     }
 }


### PR DESCRIPTION
몇몇 구조체 public 추가 인데

저희 약간 호환성을 생각해서 `entity`부분은 `Chzzk(entityname)`이렇게 하는게 어떤가요?
근데 네이버 model그대로 써도 될거 같다는 생각이 들어서 request handling 한 결과 함 보고 생각해보죠